### PR TITLE
Add Encryption option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,14 @@ PROJECT = emqx_auth_clientid
 PROJECT_DESCRIPTION = EMQ X Authentication with ClientId/Password
 PROJECT_VERSION = 3.0
 
-BUILD_DEPS = emqx cuttlefish
+DEPS = emqx_passwd clique
+dep_emqx_passwd = git-emqx https://github.com/emqx/emqx-passwd v1.0
+dep_clique      = git-emqx https://github.com/emqx/clique v0.3.11
+
+BUILD_DEPS = emqx cuttlefish emqx_management
 dep_emqx = git-emqx https://github.com/emqx/emqx emqx30
 dep_cuttlefish = git-emqx https://github.com/emqx/cuttlefish v2.2.1
+dep_emqx_management = git-emqx https://github.com/emqx/emqx-management emqx30
 
 NO_AUTOPATCH = cuttlefish
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ etc/emqx_auth_clientid.conf:
 ```
 ##auth.client.$N.clientid = clientid
 ##auth.client.$N.password = passwd
+
+## Password hash.
+##
+## Value: plain | md5 | sha | sha256 | bcrypt
+auth.client.password_hash = md5
+```
+
 ```
 
 Load the Plugin

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ etc/emqx_auth_clientid.conf:
 
 ## Password hash.
 ##
-## Value: plain | md5 | sha | sha256 | bcrypt
+## Value: plain | md5 | sha | sha256
 auth.client.password_hash = md5
 ```
 

--- a/etc/emqx_auth_clientid.conf
+++ b/etc/emqx_auth_clientid.conf
@@ -3,10 +3,10 @@
 ##--------------------------------------------------------------------
 
 ## Examples
-# auth.client.1.clientid = id
-# auth.client.1.password = passwd
-# auth.client.2.clientid = devdevid
-# auth.client.2.password = passwd2
+auth.client.1.clientid = id
+auth.client.1.password = passwd
+auth.client.2.clientid = devdevid
+auth.client.2.password = passwd2
 ##auth.client.3.clientid = app:appid
 ##auth.client.3.password = passwd3
 ##auth.client.4.clientid = client~!@#$%^&*()_+

--- a/etc/emqx_auth_clientid.conf
+++ b/etc/emqx_auth_clientid.conf
@@ -5,7 +5,7 @@
 ## Examples
 ##auth.client.1.clientid = id
 ##auth.client.1.password = passwd
-##auth.client.2.clientid = devdevid
+##auth.client.2.clientid = dev:devid
 ##auth.client.2.password = passwd2
 ##auth.client.3.clientid = app:appid
 ##auth.client.3.password = passwd3

--- a/etc/emqx_auth_clientid.conf
+++ b/etc/emqx_auth_clientid.conf
@@ -3,10 +3,10 @@
 ##--------------------------------------------------------------------
 
 ## Examples
-auth.client.1.clientid = id
-auth.client.1.password = passwd
-auth.client.2.clientid = devdevid
-auth.client.2.password = passwd2
+##auth.client.1.clientid = id
+##auth.client.1.password = passwd
+##auth.client.2.clientid = devdevid
+##auth.client.2.password = passwd2
 ##auth.client.3.clientid = app:appid
 ##auth.client.3.password = passwd3
 ##auth.client.4.clientid = client~!@#$%^&*()_+
@@ -14,5 +14,5 @@ auth.client.2.password = passwd2
 
 ## Password hash.
 ##
-## Value: plain | md5 | sha | sha256 | bcrypt
+## Value: plain | md5 | sha | sha256
 auth.client.password_hash = md5

--- a/etc/emqx_auth_clientid.conf
+++ b/etc/emqx_auth_clientid.conf
@@ -3,12 +3,16 @@
 ##--------------------------------------------------------------------
 
 ## Examples
-##auth.client.1.clientid = id
-##auth.client.1.password = passwd
-##auth.client.2.clientid = dev:devid
-##auth.client.2.password = passwd2
+# auth.client.1.clientid = id
+# auth.client.1.password = passwd
+# auth.client.2.clientid = devdevid
+# auth.client.2.password = passwd2
 ##auth.client.3.clientid = app:appid
 ##auth.client.3.password = passwd3
 ##auth.client.4.clientid = client~!@#$%^&*()_+
 ##auth.client.4.password = passwd~!@#$%^&*()_+
 
+## Password hash.
+##
+## Value: plain | md5 | sha | sha256 | bcrypt
+auth.client.password_hash = md5

--- a/include/emqx_auth_clientid.hrl
+++ b/include/emqx_auth_clientid.hrl
@@ -1,0 +1,1 @@
+-define(APP, emqx_auth_clientid).

--- a/priv/emqx_auth_clientid.schema
+++ b/priv/emqx_auth_clientid.schema
@@ -9,7 +9,7 @@
   {datatype, string}
 ]}.
 
-{mapping, "auth.client.password_hash", "emqx_auth_clientid.config", [
+{mapping, "auth.client.password_hash", "emqx_auth_clientid.password_hash", [
   {datatype, string}
 ]}.
 
@@ -23,7 +23,7 @@
   	end, [], ClientList)
 end}.
 
-{translation, "emqx_auth_clientid.config", fun(Conf) ->
+{translation, "emqx_auth_clientid.password_hash", fun(Conf) ->
   PasswordHash = cuttlefish:conf_get("auth.client.password_hash", Conf),
   HashValue =
     case string:tokens(PasswordHash, ",") of
@@ -32,5 +32,5 @@ end}.
           [Hash, MacFun, Iterations, Dklen] -> {list_to_atom(Hash), list_to_atom(MacFun), list_to_integer(Iterations), list_to_integer(Dklen)};
           _                -> plain
     end,
-    [{password_hash, HashValue}]
+    [{hash_type, HashValue}]
 end}.

--- a/priv/emqx_auth_clientid.schema
+++ b/priv/emqx_auth_clientid.schema
@@ -9,6 +9,10 @@
   {datatype, string}
 ]}.
 
+{mapping, "auth.client.password_hash", "emqx_auth_clientid.config", [
+  {datatype, string}
+]}.
+
 {translation, "emqx_auth_clientid.client_list", fun(Conf) ->
   ClientList = cuttlefish_variable:filter_by_prefix("auth.client", Conf),
   lists:foldl(
@@ -17,4 +21,16 @@
        (_, AccIn) ->
         AccIn
   	end, [], ClientList)
+end}.
+
+{translation, "emqx_auth_clientid.config", fun(Conf) ->
+  PasswordHash = cuttlefish:conf_get("auth.client.password_hash", Conf),
+  HashValue =
+    case string:tokens(PasswordHash, ",") of
+          [Hash]           -> list_to_atom(Hash);
+          [Prefix, Suffix] -> {list_to_atom(Prefix), list_to_atom(Suffix)};
+          [Hash, MacFun, Iterations, Dklen] -> {list_to_atom(Hash), list_to_atom(MacFun), list_to_integer(Iterations), list_to_integer(Dklen)};
+          _                -> plain
+    end,
+    [{password_hash, HashValue}]
 end}.

--- a/priv/emqx_auth_clientid.schema
+++ b/priv/emqx_auth_clientid.schema
@@ -31,6 +31,5 @@ end}.
           [Prefix, Suffix] -> {list_to_atom(Prefix), list_to_atom(Suffix)};
           [Hash, MacFun, Iterations, Dklen] -> {list_to_atom(Hash), list_to_atom(MacFun), list_to_integer(Iterations), list_to_integer(Dklen)};
           _                -> plain
-    end,
-    [{hash_type, HashValue}]
+    end
 end}.

--- a/priv/emqx_auth_clientid.schema
+++ b/priv/emqx_auth_clientid.schema
@@ -10,7 +10,7 @@
 ]}.
 
 {mapping, "auth.client.password_hash", "emqx_auth_clientid.password_hash", [
-  {datatype, string}
+  {datatype, atom}
 ]}.
 
 {translation, "emqx_auth_clientid.client_list", fun(Conf) ->
@@ -21,15 +21,4 @@
        (_, AccIn) ->
         AccIn
   	end, [], ClientList)
-end}.
-
-{translation, "emqx_auth_clientid.password_hash", fun(Conf) ->
-  PasswordHash = cuttlefish:conf_get("auth.client.password_hash", Conf),
-  HashValue =
-    case string:tokens(PasswordHash, ",") of
-          [Hash]           -> list_to_atom(Hash);
-          [Prefix, Suffix] -> {list_to_atom(Prefix), list_to_atom(Suffix)};
-          [Hash, MacFun, Iterations, Dklen] -> {list_to_atom(Hash), list_to_atom(MacFun), list_to_integer(Iterations), list_to_integer(Dklen)};
-          _                -> plain
-    end
 end}.

--- a/src/emqx_auth_clientid.erl
+++ b/src/emqx_auth_clientid.erl
@@ -91,12 +91,11 @@ description() ->
     "ClientId Authentication Module".
 
 encrypted_data(Password) ->
-    HashOpt = get_passwordhash_config(),
-    HashType = proplists:get_value(hash_type, HashOpt, md5),
+    HashType = get_passwordhash_config(),
     hash(Password, HashType).
     
 get_passwordhash_config() ->
-    application:get_env(emqx_auth_clientid, password_hash, []).
+    application:get_env(emqx_auth_clientid, password_hash, md5).
 
 hash(Password, HashType) ->
     emqx_passwd:hash(HashType, Password).

--- a/src/emqx_auth_clientid.erl
+++ b/src/emqx_auth_clientid.erl
@@ -64,38 +64,38 @@ init({ClientList, HashType}) ->
             {attributes, record_info(fields, ?TAB)}]),
     ok = ekka_mnesia:copy_table(?TAB, disc_copies),
     State = #state{hash_type = HashType},
-    Clients = [r(ClientId, Password, HashType) || {ClientId, Password} <- ClientList],
+    Clients = [r(ClientId, Password) || {ClientId, Password} <- ClientList],
     mnesia:transaction(fun() -> [mnesia:write(C) || C <- Clients] end),
     {ok, State}.
 
-r(ClientId, Password, HashType) ->
+r(ClientId, Password) ->
     #?TAB{client_id = iolist_to_binary(ClientId),
-          password  = hash(iolist_to_binary(Password), HashType)}.
+          password  = encrypted_data(iolist_to_binary(Password))}.
 
 check(#{client_id := undefined}, _Password, _) ->
     {error, clientid_undefined};
 check(_Credentials, undefined, _) ->
     {error, password_undefined};
-check(#{client_id := ClientId}, Password, #state{hash_type = HashType}) ->
-    case mnesia:dirty_read(?TAB, ClientId) of
+check(#{client_id := Client}, Password, #state{hash_type = HashType}) ->
+    case mnesia:dirty_read(?TAB, Client) of
         [] -> ignore;
-        [#?TAB{password = Password1}] ->
-
-            case Password1 =:= hash(Password, HashType) of
+        [#?TAB{password = <<Salt:4/binary, Hash/binary>>}] ->
+            case Hash =:= hash(Password, Salt, HashType) of
                 true -> ok;
                 false -> {error, password_error}
             end
-        end.
+    end.
 
 description() ->
     "ClientId Authentication Module".
 
 encrypted_data(Password) ->
-    HashType = get_passwordhash_config(),
-    hash(Password, HashType).
-    
-get_passwordhash_config() ->
-    application:get_env(emqx_auth_clientid, password_hash, md5).
+    HashType = application:get_env(emqx_auth_clientid, password_hash, md5),
+    SaltBin = salt(),
+    <<SaltBin/binary, (hash(Password, SaltBin, HashType))/binary>>.
 
-hash(Password, HashType) ->
-    emqx_passwd:hash(HashType, Password).
+hash(Password, SaltBin, HashType) ->
+    emqx_passwd:hash(HashType, <<SaltBin/binary, Password/binary>>).
+
+salt() ->
+    emqx_time:seed(), Salt = rand:uniform(16#ffffffff), <<Salt:32>>.

--- a/src/emqx_auth_clientid.erl
+++ b/src/emqx_auth_clientid.erl
@@ -98,4 +98,5 @@ hash(Password, SaltBin, HashType) ->
     emqx_passwd:hash(HashType, <<SaltBin/binary, Password/binary>>).
 
 salt() ->
-    emqx_time:seed(), Salt = rand:uniform(16#ffffffff), <<Salt:32>>.
+    rand:seed(exsplus, erlang:timestamp()),
+    Salt = rand:uniform(16#ffffffff), <<Salt:32>>.

--- a/src/emqx_auth_clientid_app.erl
+++ b/src/emqx_auth_clientid_app.erl
@@ -26,7 +26,8 @@
 
 start(_Type, _Args) ->
     ClientList = application:get_env(?APP, client_list, []),
-    HashType = application:get_env(?APP, password_hash, md5),
+    HashType = application:get_env(?APP, password_hash, md5), 
+    io:format("ssds ~p~n", [{ClientList, HashType}]),
     emqx_access_control:register_mod(auth, ?APP, {ClientList, HashType}),
     emqx_auth_clientid_cfg:register(),
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).

--- a/src/emqx_auth_clientid_app.erl
+++ b/src/emqx_auth_clientid_app.erl
@@ -26,8 +26,7 @@
 
 start(_Type, _Args) ->
     ClientList = application:get_env(?APP, client_list, []),
-    HashOpt = application:get_env(?APP, password_hash, []),
-    HashType = proplists:get_value(hash_type, HashOpt),
+    HashType = application:get_env(?APP, password_hash, md5),
     emqx_access_control:register_mod(auth, ?APP, {ClientList, HashType}),
     emqx_auth_clientid_cfg:register(),
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).

--- a/src/emqx_auth_clientid_app.erl
+++ b/src/emqx_auth_clientid_app.erl
@@ -27,7 +27,6 @@
 start(_Type, _Args) ->
     ClientList = application:get_env(?APP, client_list, []),
     HashType = application:get_env(?APP, password_hash, md5), 
-    io:format("ssds ~p~n", [{ClientList, HashType}]),
     emqx_access_control:register_mod(auth, ?APP, {ClientList, HashType}),
     emqx_auth_clientid_cfg:register(),
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).

--- a/src/emqx_auth_clientid_app.erl
+++ b/src/emqx_auth_clientid_app.erl
@@ -26,8 +26,8 @@
 
 start(_Type, _Args) ->
     ClientList = application:get_env(?APP, client_list, []),
-    HashOpt = application:get_env(?APP, config, []),
-    HashType = proplists:get_value(password_hash, HashOpt),
+    HashOpt = application:get_env(?APP, password_hash, []),
+    HashType = proplists:get_value(hash_type, HashOpt),
     emqx_access_control:register_mod(auth, ?APP, {ClientList, HashType}),
     emqx_auth_clientid_cfg:register(),
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).

--- a/src/emqx_auth_clientid_app.erl
+++ b/src/emqx_auth_clientid_app.erl
@@ -26,10 +26,14 @@
 
 start(_Type, _Args) ->
     ClientList = application:get_env(?APP, client_list, []),
-    emqx_access_control:register_mod(auth, ?APP, ClientList),
+    HashOpt = application:get_env(?APP, config, []),
+    HashType = proplists:get_value(password_hash, HashOpt),
+    emqx_access_control:register_mod(auth, ?APP, {ClientList, HashType}),
+    emqx_auth_clientid_cfg:register(),
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 stop(_State) ->
+    emqx_auth_clientid_cfg:unregister(),
     emqx_access_control:unregister_mod(auth, ?APP).
 
 %%--------------------------------------------------------------------

--- a/src/emqx_auth_clientid_cfg.erl
+++ b/src/emqx_auth_clientid_cfg.erl
@@ -1,0 +1,85 @@
+%% Copyright (c) 2018 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module (emqx_auth_clientid_cfg).
+
+-include("emqx_auth_clientid.hrl").
+
+-export ([register/0, unregister/0]).
+
+register() ->
+    clique_config:load_schema([code:priv_dir(?APP)], ?APP),
+    register_formatter(),
+    register_config().
+
+unregister() ->
+    unregister_formatter(),
+    unregister_config(),
+    clique_config:unload_schema(?APP).
+
+register_formatter() ->
+    [clique:register_formatter(cuttlefish_variable:tokenize(Key),
+     fun formatter_callback/2) || Key <- keys()].
+
+formatter_callback([_, _, "password_hash"], Params) when is_atom(Params) ->
+    Params;
+formatter_callback([_, _, "password_hash"], Params) when is_tuple(Params) ->
+    format(tuple_to_list(Params));
+formatter_callback([_, _, Key], Params) ->
+    proplists:get_value(list_to_atom(Key), Params).
+
+unregister_formatter() ->
+    [clique:unregister_formatter(cuttlefish_variable:tokenize(Key)) || Key <- keys()].
+
+register_config() ->
+    Keys = keys(),
+    [clique:register_config(Key , fun config_callback/2) || Key <- Keys],
+    clique:register_config_whitelist(Keys, ?APP).
+
+config_callback([_, _, "password_hash"], Value0) ->
+    Value = parse_password_hash(Value0),
+    application:set_env(?APP, password_hash, Value),
+    " successfully\n";
+config_callback([_, _, Key0], Value) ->
+    Key = list_to_atom(Key0),
+    {ok, Env} = application:get_env(?APP, server),
+    application:set_env(?APP, server, lists:keyreplace(Key, 1, Env, {Key, Value})),
+    " successfully\n".
+
+unregister_config() ->
+    Keys = keys(),
+    [clique:unregister_config(Key) || Key <- Keys],
+    clique:unregister_config_whitelist(Keys, ?APP).
+
+keys() ->
+    ["auth.client.password_hash"].
+
+format(Value) ->
+    format(Value, "").
+format([Head], Acc) ->
+    lists:concat([Acc, Head]);
+format([Head | Tail], Acc) ->
+    format(Tail, Acc ++ lists:concat([Head, ","])).
+
+parse_password_hash(Value) ->
+    case string:tokens(Value, ",") of
+          [Hash]           -> list_to_atom(Hash);
+          [Prefix, Suffix] -> {list_to_atom(Prefix), list_to_atom(Suffix)};
+          [Hash, MacFun, Iterations, Dklen] -> {list_to_atom(Hash),
+                                                list_to_atom(MacFun),
+                                                list_to_integer(Iterations),
+                                                list_to_integer(Dklen)};
+          _                -> plain
+    end.
+

--- a/test/emqx_auth_clientid_SUITE.erl
+++ b/test/emqx_auth_clientid_SUITE.erl
@@ -29,22 +29,36 @@ groups() ->
 init_per_suite(Config) ->
     [start_apps(App, {SchemaFile, ConfigFile}) ||
         {App, SchemaFile, ConfigFile}
-            <- [{emqx, local_path("deps/emqx/priv/emqx.schema"),
-                       local_path("deps/emqx/etc/emqx.conf")},
+            <- [{emqx, deps_path(emqx, "priv/emqx.schema"),
+                       deps_path(emqx, "etc/emqx.conf")},
+                {emqx_management, deps_path(emqx_management, "priv/emqx_management.schema"),
+                                  deps_path(emqx_management, "etc/emqx_management.conf")},
                 {emqx_auth_clientid, local_path("priv/emqx_auth_clientid.schema"),
                                      local_path("etc/emqx_auth_clientid.conf")}]],
     Config.
 
 end_per_suite(_Config) ->
     application:stop(emqx_auth_clientid),
+    application:stop((emqx_management)),
     application:stop(emqx).
 
-get_base_dir() ->
-    {file, Here} = code:is_loaded(?MODULE),
-    filename:dirname(filename:dirname(Here)).
+% get_base_dir() ->
+%     {file, Here} = code:is_loaded(?MODULE),
+%     filename:dirname(filename:dirname(Here)).
+
+deps_path(App, RelativePath) ->
+    %% Note: not lib_dir because etc dir is not sym-link-ed to _build dir
+    %% but priv dir is
+    Path0 = code:priv_dir(App),
+    Path = case file:read_link(Path0) of
+               {ok, Resolved} -> Resolved;
+               {error, _} -> Path0
+           end,
+    filename:join([Path, "..", RelativePath]).
 
 local_path(RelativePath) ->
-    filename:join([get_base_dir(), RelativePath]).
+    % filename:join([get_base_dir(), RelativePath]).
+    deps_path(emqx_auth_clientid, RelativePath).
 
 start_apps(App, {SchemaFile, ConfigFile}) ->
     read_schema_configs(App, {SchemaFile, ConfigFile}),
@@ -63,25 +77,30 @@ set_special_configs(emqx) ->
     application:set_env(emqx, allow_anonymous, false),
     application:set_env(emqx, enable_acl_cache, false),
     application:set_env(emqx, plugins_loaded_file,
-                        local_path("deps/emqx/test/emqx_SUITE_data/loaded_plugins"));
+                        deps_path(emqx, "test/emqx_SUITE_data/loaded_plugins"));
 set_special_configs(_App) ->
     ok.
 
 emqx_auth_clientid_api(_Config) ->
     {atomic, ok} = emqx_auth_clientid:add_clientid(<<"emq_auth_clientid">>, <<"password">>),
     User1 = #{client_id => <<"emq_auth_clientid">>},
-    [{emqx_auth_clientid,<<"emq_auth_clientid">>,<<"password">>}] =
-        emqx_auth_clientid:lookup_clientid(<<"emq_auth_clientid">>),
+    [{emqx_auth_clientid,<<"emq_auth_clientid">>, _}] =
+    emqx_auth_clientid:lookup_clientid(<<"emq_auth_clientid">>),
     ok = emqx_access_control:authenticate(User1, <<"password">>),
+    emqx_access_control:authenticate(User1, <<"password">>),
     ok = emqx_auth_clientid:remove_clientid(<<"emq_auth_clientid">>),
     {error, _} = emqx_access_control:authenticate(User1, <<"password">>).
 
 change_config(_Config) ->
     application:stop(emqx_auth_clientid),
-    application:set_env(emqx_auth_clientid, client_list, [{"id", "password"}, {"dev:devid", "passwd2"}]),
-    application:start(emqx_auth_clientid),
-    User1 = #{client_id => <<"id">>},
+    application:set_env(emqx_auth_clientid, client_list,
+                        [{"id1", "password1"}, {"dev:devid", "passwd2"}]),
+    ok = application:start(emqx_auth_clientid),
+    User1 = #{client_id => <<"id1">>},
     User2 = #{client_id => <<"dev:devid">>},
-    ok = emqx_access_control:authenticate(User1, <<"password">>),
+    ok = emqx_access_control:authenticate(User1, <<"password1">>),
     {error, password_error} = emqx_access_control:authenticate(User1, <<"password00">>),
-    ok = emqx_access_control:authenticate(User2, <<"passwd2">>).
+    ok = emqx_access_control:authenticate(User2, <<"passwd2">>),
+    %% clean data
+    ok = emqx_auth_clientid:remove_clientid(<<"id1">>),
+    ok = emqx_auth_clientid:remove_clientid(<<"dev:devid">>).

--- a/test/emqx_auth_clientid_SUITE.erl
+++ b/test/emqx_auth_clientid_SUITE.erl
@@ -94,11 +94,11 @@ emqx_auth_clientid_api(_Config) ->
 change_config(_Config) ->
     application:stop(emqx_auth_clientid),
     application:set_env(emqx_auth_clientid, client_list,
-                        [{"id1", "password1"}, {"dev:devid", "passwd2"}]),
+                        [{"id", "password"}, {"dev:devid", "passwd2"}]),
     ok = application:start(emqx_auth_clientid),
-    User1 = #{client_id => <<"id1">>},
+    User1 = #{client_id => <<"id">>},
     User2 = #{client_id => <<"dev:devid">>},
-    ok = emqx_access_control:authenticate(User1, <<"password1">>),
+    ok = emqx_access_control:authenticate(User1, <<"password">>),
     {error, password_error} = emqx_access_control:authenticate(User1, <<"password00">>),
     ok = emqx_access_control:authenticate(User2, <<"passwd2">>),
     %% clean data


### PR DESCRIPTION
Description:
   Add a encryption options about encryption of passwords. Supported encryption modes include: plain  md5 sha sha256 ,
`## Value: plain | md5 | sha | sha256 
 ##auth.client.password_hash = md5`