### PR TITLE
add library deps to applications

### DIFF
--- a/src/emqx_auth_clientid.app.src
+++ b/src/emqx_auth_clientid.app.src
@@ -3,5 +3,5 @@
               {vsn,"git"},
               {modules,[]},
               {registered,[emqx_auth_clientid_sup]},
-              {applications,[kernel,stdlib,clique]},
+              {applications,[kernel,stdlib,clique,minirest, emqx_passwd]},
               {mod,{emqx_auth_clientid_app,[]}}]}.


### PR DESCRIPTION
To play well with release tools, OTP Guide recommends adding library dependencies to applications in app.src

emqx is another hard app dependency, and should technically also be added, but I am hesistant to add it right now.